### PR TITLE
Bugfix: Add hidden form field for form-name

### DIFF
--- a/src/components/Form/form.js
+++ b/src/components/Form/form.js
@@ -3,7 +3,15 @@ import formStyles from '../../css/forms.module.css'
 
 const Form = ({name, children}) => {
   return (
-    <form action="/contact/success" name={name} method="POST" className={formStyles.form} data-netlify="true" netlify-honeypot="more-infos">
+    <form
+      action="/contact/success"
+      name={name}
+      method="POST"
+      className={formStyles.form}
+      data-netlify="true"
+      netlify-honeypot="more-infos"
+    >
+      <input type="hidden" name="form-name" value={name} />
       <input name="more-infos" />
       {children}
     </form>


### PR DESCRIPTION
Gatsby strips out input fields that are not included in the JSX form, so you will still need to add the form-name hidden input field as described in.